### PR TITLE
Update API endpoints for MaxMind products and services

### DIFF
--- a/Data/TTP/T1497_Virtualization-Sandbox_Evasion/T1497.md
+++ b/Data/TTP/T1497_Virtualization-Sandbox_Evasion/T1497.md
@@ -136,7 +136,7 @@ End Sub
 
 Public Function GeoTest() As String
  Set a = CreateObject("WinHttp.WinHttpRequest.5.1")
- a.Open "GET", "https://www.maxmind.com/geoip/v2.1/city/me", False
+ a.Open "GET", "https://geoip.maxmind.com/geoip/v2.1/city/me", False
  a.SetRequestHeader "Referer", "https://www.maxmind.com/en/locate-my-ip-address"
  a.SetRequestHeader "User-Agent", "Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0; Trident/5.0)"
  a.Send


### PR DESCRIPTION
MaxMind is beginning to enforce policies around its API endpoints. Endpoints should use the correct hostname for the product or service, and should always use HTTPS.

[Release Note.](https://dev.maxmind.com/geoip/release-notes/2023#api-policies---temporary-enforcement-on-october-17-2023)